### PR TITLE
feat: Vimeo Live Discovery (SPEC-014)

### DIFF
--- a/scripts/connectors/vimeo.py
+++ b/scripts/connectors/vimeo.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Vimeo VTT Connector — download auto-generated captions from SPC-TV videos.
+"""Vimeo VTT Connector — live discovery of SPC-TV channel videos.
 
-Uses yt-dlp to fetch VTT subtitle files. No API token required.
+Enumerates the SPC-TV Vimeo channel on every run, filters to FY27-relevant
+meetings, and downloads VTTs for videos not already local. Uses
+pipeline.discovery.DiscoveryHistory for attempt tracking and backoff.
+
+No API token required — uses yt-dlp for both channel enumeration and download.
 
 Usage:
-    python3 scripts/connectors/vimeo.py                  # download all missing VTTs
-    python3 scripts/connectors/vimeo.py --check-only     # list what would be downloaded
-    python3 scripts/connectors/vimeo.py --vimeo-id ID    # process a single video
-    python3 scripts/connectors/vimeo.py --discover        # find and add new channel videos
+    python3 scripts/connectors/vimeo.py              # download all missing VTTs
+    python3 scripts/connectors/vimeo.py --check-only # list what would be downloaded
 """
 
 import argparse
@@ -20,7 +22,12 @@ import sys
 import tempfile
 import shutil
 
-import yaml
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
+
+# Add project root to path so pipeline.discovery is importable
+sys.path.insert(0, PROJECT_ROOT)
+from pipeline.discovery import DiscoveryHistory  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -29,22 +36,37 @@ logging.basicConfig(
 )
 log = logging.getLogger("vimeo-connector")
 
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
-DEFAULT_CONFIG = os.path.join(SCRIPT_DIR, "vimeo-sources.yaml")
+# ---------------------------------------------------------------------------
+# Filter criteria (top-level constants for easy FY adjustment)
+# ---------------------------------------------------------------------------
 
-# Channel URL template — the /videos page is a playlist yt-dlp can enumerate
-CHANNEL_URL = "https://vimeo.com/{channel}/videos"
+CHANNEL_ID = "spctv"
+CHANNEL_URL = f"https://vimeo.com/{CHANNEL_ID}/videos"
+
+TITLE_PREFIXES = ["spboe_", "spcc_", "spccws_"]
+DATE_CUTOFF = "2025-12-01"
+
+# Title prefix → data directory subtree
+PREFIX_TO_TYPE = {
+    "spboe_": "school-board",
+    "spcc_": "city-council",
+    "spccws_": "city-council",
+}
+
+# History file per meeting type
+HISTORY_PATHS = {
+    "school-board": os.path.join(
+        PROJECT_ROOT, "data", "school-board", "meetings", "discovery.jsonl"
+    ),
+    "city-council": os.path.join(
+        PROJECT_ROOT, "data", "city-council", "meetings", "discovery.jsonl"
+    ),
+}
 
 
-def load_config(config_path):
-    """Load and validate the sources config. Returns the full config dict."""
-    with open(config_path, "r") as f:
-        config = yaml.safe_load(f)
-    sources = config.get("sources", [])
-    if not sources:
-        log.warning("No sources found in config file")
-    return config
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def check_yt_dlp():
@@ -52,56 +74,6 @@ def check_yt_dlp():
     if not shutil.which("yt-dlp"):
         log.error("yt-dlp not found on PATH. Install with: brew install yt-dlp")
         sys.exit(1)
-
-
-def download_vtt(vimeo_id, output_path):
-    """Download VTT captions for a single Vimeo video.
-
-    Returns True on success, False on failure.
-    """
-    output_dir = os.path.dirname(output_path)
-    os.makedirs(output_dir, exist_ok=True)
-
-    # yt-dlp writes to a pattern-based filename; we use a temp dir and move
-    with tempfile.TemporaryDirectory() as tmpdir:
-        cmd = [
-            "yt-dlp",
-            "--write-sub",
-            "--sub-lang", "en-x-autogen",
-            "--sub-format", "vtt",
-            "--skip-download",
-            "--no-warnings",
-            "-o", os.path.join(tmpdir, "video.%(ext)s"),
-            f"https://vimeo.com/{vimeo_id}",
-        ]
-
-        try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=60
-            )
-        except subprocess.TimeoutExpired:
-            log.error("Timeout downloading VTT for Vimeo ID %s", vimeo_id)
-            return False
-
-        if result.returncode != 0:
-            stderr = result.stderr.strip()
-            if "no subtitles" in stderr.lower() or "no subtitle" in stderr.lower():
-                log.warning("No auto-generated captions for Vimeo ID %s", vimeo_id)
-            else:
-                log.error(
-                    "yt-dlp failed for Vimeo ID %s (exit %d): %s",
-                    vimeo_id, result.returncode, stderr[:200],
-                )
-            return False
-
-        # Find the downloaded VTT file
-        vtt_files = [f for f in os.listdir(tmpdir) if f.endswith(".vtt")]
-        if not vtt_files:
-            log.warning("No VTT file produced for Vimeo ID %s", vimeo_id)
-            return False
-
-        shutil.move(os.path.join(tmpdir, vtt_files[0]), output_path)
-        return True
 
 
 def discover_channel(channel_id):
@@ -147,6 +119,45 @@ def discover_channel(channel_id):
     return videos
 
 
+def matches_filters(video, prefixes, after_date):
+    """Check if a video matches the discovery filters.
+
+    Args:
+        video:      dict with 'title' and 'upload_date' keys
+        prefixes:   list of title prefixes to match (e.g., ['spboe_', 'spcc_'])
+        after_date: minimum date string (YYYY-MM-DD) or None
+    """
+    title = video.get("title", "").lower()
+
+    if prefixes:
+        if not any(title.startswith(p.lower()) for p in prefixes):
+            return False
+
+    if after_date:
+        video_date = None
+        upload = video.get("upload_date", "")
+        if upload and len(upload) == 8:
+            video_date = f"{upload[:4]}-{upload[4:6]}-{upload[6:8]}"
+        else:
+            m = re.search(r"(\d{8})", title)
+            if m:
+                d = m.group(1)
+                video_date = f"{d[:4]}-{d[4:6]}-{d[6:8]}"
+        if video_date and video_date < after_date:
+            return False
+
+    return True
+
+
+def infer_meeting_type(title):
+    """Return the meeting type ('school-board' or 'city-council') from title."""
+    lower = title.lower()
+    for prefix, mtype in PREFIX_TO_TYPE.items():
+        if lower.startswith(prefix):
+            return mtype
+    return "school-board"  # default for SPC-TV
+
+
 def infer_metadata(video):
     """Infer meeting type, subtype, date, and output path from video metadata.
 
@@ -155,15 +166,8 @@ def infer_metadata(video):
     title = video.get("title", "").lower()
     vimeo_id = video["id"]
 
-    # Infer meeting type from title
-    if "school board" in title or "school dept" in title or "school department" in title:
-        meeting_type = "school-board"
-    elif "city council" in title or "council" in title:
-        meeting_type = "city-council"
-    else:
-        meeting_type = "school-board"  # default for SPC-TV
+    meeting_type = infer_meeting_type(video.get("title", ""))
 
-    # Infer subtype from title
     if "budget forum" in title:
         subtype = "budget-forum"
     elif "budget workshop" in title:
@@ -173,18 +177,15 @@ def infer_metadata(video):
     else:
         subtype = "regular-meeting"
 
-    # Infer date from upload_date (YYYYMMDD) or title
     upload_date = video.get("upload_date", "")
     if upload_date and len(upload_date) == 8:
         date = f"{upload_date[:4]}-{upload_date[4:6]}-{upload_date[6:8]}"
     else:
-        # Try YYYYMMDD embedded in title (SPC-TV convention: "spboe_20260309 - ...")
         m = re.search(r"(\d{8})", video.get("title", ""))
         if m:
             d = m.group(1)
             date = f"{d[:4]}-{d[4:6]}-{d[6:8]}"
         else:
-            # Try M/D/YYYY or M-D-YYYY
             m = re.search(r"(\d{1,2})[/-](\d{1,2})[/-](\d{2,4})", video.get("title", ""))
             if m:
                 month, day, year = m.group(1), m.group(2), m.group(3)
@@ -194,7 +195,6 @@ def infer_metadata(video):
             else:
                 date = "unknown"
 
-    # Build output path
     dir_name = date
     if subtype != "regular-meeting":
         dir_name = f"{date}-{subtype}"
@@ -210,185 +210,142 @@ def infer_metadata(video):
     }
 
 
-def save_config(config_path, config):
-    """Write the config back to YAML, preserving comments at top."""
-    # Read original to preserve header comments
-    with open(config_path, "r") as f:
-        original = f.read()
+def download_vtt(vimeo_id, output_path):
+    """Download VTT captions for a single Vimeo video.
 
-    header_lines = []
-    for line in original.split("\n"):
-        if line.startswith("#") or line.strip() == "":
-            header_lines.append(line)
-        else:
-            break
-
-    header = "\n".join(header_lines)
-    if header:
-        header += "\n\n"
-
-    body = yaml.dump(config, default_flow_style=False, sort_keys=False)
-
-    with open(config_path, "w") as f:
-        f.write(header)
-        f.write(body)
-
-
-def matches_filters(video, prefixes, after_date):
-    """Check if a video matches the discovery filters.
-
-    Args:
-        video: dict with 'title' and 'upload_date' keys
-        prefixes: list of title prefixes to match (e.g., ['spboe_', 'spcc_'])
-        after_date: minimum date string (YYYY-MM-DD) or None
+    Returns (success: bool, error_msg: str).
     """
-    title = video.get("title", "").lower()
+    output_dir = os.path.dirname(output_path)
+    os.makedirs(output_dir, exist_ok=True)
 
-    # Prefix filter
-    if prefixes:
-        if not any(title.startswith(p.lower()) for p in prefixes):
-            return False
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cmd = [
+            "yt-dlp",
+            "--write-sub",
+            "--sub-lang", "en-x-autogen",
+            "--sub-format", "vtt",
+            "--skip-download",
+            "--no-warnings",
+            "-o", os.path.join(tmpdir, "video.%(ext)s"),
+            f"https://vimeo.com/{vimeo_id}",
+        ]
 
-    # Date filter — extract date from upload_date or title (SPC-TV embeds YYYYMMDD in titles)
-    if after_date:
-        video_date = None
-        upload = video.get("upload_date", "")
-        if upload and len(upload) == 8:
-            video_date = f"{upload[:4]}-{upload[4:6]}-{upload[6:8]}"
-        else:
-            # Extract YYYYMMDD from title (e.g., "spboe_20260309" or "spcc_ws_20251113")
-            m = re.search(r'(\d{8})', title)
-            if m:
-                d = m.group(1)
-                video_date = f"{d[:4]}-{d[4:6]}-{d[6:8]}"
-        if video_date and video_date < after_date:
-            return False
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=60
+            )
+        except subprocess.TimeoutExpired:
+            msg = f"Timeout downloading VTT for Vimeo ID {vimeo_id}"
+            log.error(msg)
+            return False, msg
 
-    return True
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            if "no subtitles" in stderr.lower() or "no subtitle" in stderr.lower():
+                msg = f"No auto-generated captions for Vimeo ID {vimeo_id}"
+                log.warning(msg)
+            else:
+                msg = (
+                    f"yt-dlp failed for Vimeo ID {vimeo_id} "
+                    f"(exit {result.returncode}): {stderr[:200]}"
+                )
+                log.error(msg)
+            return False, result.stderr.strip()[:200]
 
+        vtt_files = [f for f in os.listdir(tmpdir) if f.endswith(".vtt")]
+        if not vtt_files:
+            msg = f"No VTT file produced for Vimeo ID {vimeo_id}"
+            log.warning(msg)
+            return False, msg
 
-def discover_and_update(config_path, dry_run=False):
-    """Discover new channel videos and add them to config.
-
-    Args:
-        config_path: path to vimeo-sources.yaml
-        dry_run: if True, report findings without writing to config
-
-    Returns the number of new entries found/added.
-    """
-    config = load_config(config_path)
-    channel_id = config.get("channel", "spctv")
-    sources = config.get("sources", [])
-    prefixes = config.get("discover_prefixes", [])
-    after_date = config.get("discover_after", None)
-
-    # Get known video IDs
-    known_ids = {str(s["vimeo_id"]) for s in sources}
-
-    # Discover channel videos
-    videos = discover_channel(channel_id)
-    if not videos:
-        log.info("No videos found on channel (or channel listing failed)")
-        return 0
-
-    # Filter to relevant videos only
-    relevant = [v for v in videos if matches_filters(v, prefixes, after_date)]
-    if prefixes or after_date:
-        log.info("Filtered to %d relevant video(s) (from %d total)",
-                 len(relevant), len(videos))
-
-    # Find new videos
-    new_videos = [v for v in relevant if v["id"] not in known_ids]
-    if not new_videos:
-        log.info("All %d relevant channel videos are already in config", len(relevant))
-        return 0
-
-    log.info("Found %d new video(s) not in config:", len(new_videos))
-
-    added = 0
-    for video in new_videos:
-        meta = infer_metadata(video)
-        log.info("  NEW: %s — %s/%s %s (Vimeo %s)",
-                 video.get("title", "?"), meta["type"], meta["subtype"],
-                 meta["date"], meta["vimeo_id"])
-
-        if not dry_run:
-            sources.append(meta)
-        added += 1
-
-    if dry_run:
-        log.info("Dry run — %d new entry/entries found (config not modified)", added)
-    else:
-        # Save updated config
-        config["sources"] = sources
-        save_config(config_path, config)
-        log.info("Added %d new entry/entries to %s", added, os.path.basename(config_path))
-
-    return added
+        shutil.move(os.path.join(tmpdir, vtt_files[0]), output_path)
+        return True, ""
 
 
-def run(config_path, check_only=False, single_id=None, discover=False):
-    """Main connector logic."""
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+def run(check_only=False):
+    """Enumerate SPC-TV channel, filter, diff against disk, download missing."""
     check_yt_dlp()
 
-    # Discovery phase: find new videos and add to config
-    if discover:
-        new_count = discover_and_update(config_path, dry_run=check_only)
-        if new_count > 0 and not check_only:
-            log.info("Discovery added %d new source(s) — proceeding to download", new_count)
-        elif new_count > 0:
-            log.info("Discovery found %d new source(s) (dry run)", new_count)
-        else:
-            log.info("Discovery complete — no new sources found")
+    videos = discover_channel(CHANNEL_ID)
+    if not videos:
+        log.warning("No videos returned from channel — exiting")
+        return 0
 
-    config = load_config(config_path)
-    sources = config.get("sources", [])
+    relevant = [v for v in videos if matches_filters(v, TITLE_PREFIXES, DATE_CUTOFF)]
+    log.info(
+        "Filtered to %d relevant video(s) (from %d total, prefixes=%s, after=%s)",
+        len(relevant), len(videos), TITLE_PREFIXES, DATE_CUTOFF,
+    )
 
-    if single_id:
-        sources = [s for s in sources if str(s["vimeo_id"]) == str(single_id)]
-        if not sources:
-            log.error("Vimeo ID %s not found in config", single_id)
-            return 1
+    if not relevant:
+        log.info("No relevant videos found — nothing to do")
+        return 0
 
-    stats = {"skipped": 0, "downloaded": 0, "failed": 0, "would_download": 0}
+    # Lazy-load history instances per meeting type
+    histories = {}
 
-    for source in sources:
-        vimeo_id = source["vimeo_id"]
-        output_path = os.path.join(PROJECT_ROOT, source["output"])
-        label = f"{source['type']}/{source['date']} (Vimeo {vimeo_id})"
+    def get_history(meeting_type):
+        if meeting_type not in histories:
+            histories[meeting_type] = DiscoveryHistory(HISTORY_PATHS[meeting_type])
+        return histories[meeting_type]
 
+    stats = {"skipped": 0, "backoff": 0, "downloaded": 0, "failed": 0, "would_download": 0}
+
+    for video in relevant:
+        meta = infer_metadata(video)
+        vimeo_id = meta["vimeo_id"]
+        output_path = os.path.join(PROJECT_ROOT, meta["output"])
+        vimeo_url = f"https://vimeo.com/{vimeo_id}"
+        label = f"{meta['type']}/{meta['date']} (Vimeo {vimeo_id})"
+        history = get_history(meta["type"])
+
+        # Diff against disk — primary gate
         if os.path.exists(output_path):
             log.info("SKIP %s — already exists", label)
             stats["skipped"] += 1
             continue
 
+        # Backoff check for previously failed URLs
+        if not history.should_attempt(vimeo_url):
+            log.debug("BACKOFF %s — within backoff window", label)
+            stats["backoff"] += 1
+            continue
+
         if check_only:
-            log.info("WOULD DOWNLOAD %s → %s", label, source["output"])
+            log.info("WOULD DOWNLOAD %s → %s", label, meta["output"])
             stats["would_download"] += 1
             continue
 
         log.info("DOWNLOADING %s", label)
-        if download_vtt(vimeo_id, output_path):
+        success, error_msg = download_vtt(vimeo_id, output_path)
+        if success:
             file_size = os.path.getsize(output_path)
             log.info("OK %s — %d bytes", label, file_size)
+            history.record_attempt(vimeo_url, label, "ok")
             stats["downloaded"] += 1
         else:
+            history.record_attempt(vimeo_url, label, "failed", error_msg)
             stats["failed"] += 1
 
-    # Summary
     log.info("---")
     if check_only:
         log.info(
-            "Check complete: %d would download, %d already exist",
-            stats["would_download"], stats["skipped"],
+            "Check complete: %d would download, %d already exist, %d in backoff",
+            stats["would_download"], stats["skipped"], stats["backoff"],
         )
     else:
         log.info(
-            "Done: %d downloaded, %d skipped, %d failed",
-            stats["downloaded"], stats["skipped"], stats["failed"],
+            "Done: %d downloaded, %d skipped, %d failed, %d in backoff",
+            stats["downloaded"], stats["skipped"], stats["failed"], stats["backoff"],
         )
 
-    return 1 if stats["failed"] > 0 else 0
+    # Exit 0 on partial success — individual failures are non-fatal
+    return 0
 
 
 def main():
@@ -397,22 +354,8 @@ def main():
         "--check-only", action="store_true",
         help="List what would be downloaded without downloading",
     )
-    parser.add_argument(
-        "--vimeo-id", type=str,
-        help="Process a single Vimeo video ID",
-    )
-    parser.add_argument(
-        "--discover", action="store_true",
-        help="Discover new videos from the SPC-TV channel and add to config",
-    )
-    parser.add_argument(
-        "--config", type=str, default=DEFAULT_CONFIG,
-        help="Path to vimeo-sources.yaml",
-    )
     args = parser.parse_args()
-
-    sys.exit(run(args.config, check_only=args.check_only,
-                 single_id=args.vimeo_id, discover=args.discover))
+    sys.exit(run(check_only=args.check_only))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Refactors `scripts/connectors/vimeo.py` to enumerate SPC-TV channel live every run
- Removes dependency on `vimeo-sources.yaml` static config
- Adds its own `pipeline/discovery.py` (will conflict with #5 — rebase needed after #5 merges)

Closes #3

## Merge order
Merge **after** PR #5 (SPEC-013), then rebase to use the shared `DiscoveryHistory` class.

## Test plan
- [ ] Review Vimeo connector refactor for correct channel enumeration and filtering
- [ ] Verify VTT download logic for new vs existing videos
- [ ] Run `python3 scripts/connectors/vimeo.py` against live SPC-TV channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)